### PR TITLE
docs: add Cursor Cloud agent environment notes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,13 @@ Never violate this dependency order:
 - Run targeted tests when scope or risk requires them; avoid the ambiguous root
   `yarn test` alias.
 
+## Cursor Cloud specific instructions
+
+- Install: `yarn setup:env` then `yarn` (Node >= 22.12, Yarn 4.12).
+- Desktop UI: `yarn app:desktop` on `DISPLAY=:99`; CDP `127.0.0.1:9222`;
+  renderer `:3001`; verify with `/1k-ui-verify`.
+- `onekeyd` uses `-u=false -e 21324` (no USB). iOS/Android are unavailable.
+
 Use `.skillshare/skills` for detailed workflows instead of duplicating them here.
 `apps/cli/` has separate guidance; external wallet CLI skills belong in
 `https://github.com/OneKeyHQ/onekey-wallet-skills`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a short Cursor Cloud section to `CLAUDE.md` / `AGENTS.md` so future agents know how this Linux VM is set up:

- `yarn setup:env` then `yarn` for install
- Desktop UI on `DISPLAY=:99` with CDP `127.0.0.1:9222` and renderer `:3001`
- `onekeyd` runs without USB (`-u=false -e 21324`); native iOS/Android are unavailable

The dashboard Cloud Agent install/start scripts are proposed separately and still need Save in the Environment panel.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-de03d654-1ac2-4b67-ad46-3dc2f3047fe7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de03d654-1ac2-4b67-ad46-3dc2f3047fe7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

